### PR TITLE
Yosys support for qlf_k6n10 device

### DIFF
--- a/techlibs/quicklogic/Makefile.inc
+++ b/techlibs/quicklogic/Makefile.inc
@@ -4,4 +4,10 @@ OBJS += techlibs/quicklogic/synth_quicklogic.o
 $(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/cells_sim.v))
 $(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k4n8_cells_sim.v))
 $(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k4n8_arith_map.v))
-
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k4n8_ffs_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_cells_sim.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_arith_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_lut_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_ffs_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_brams_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/qlf_k6n10_brams.txt))

--- a/techlibs/quicklogic/qlf_k4n8_arith_map.v
+++ b/techlibs/quicklogic/qlf_k4n8_arith_map.v
@@ -49,15 +49,15 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             if (_TECHMAP_CONSTMSK_CI_ == 1) begin
 
                 localparam INIT = (_TECHMAP_CONSTVAL_CI_ == 0) ?
-                    16'b0110_0000_0000_0001 :
-                    16'b1001_0000_0000_0111;
+                    16'b0110_0110_0000_1000:
+                    16'b1001_1001_0000_1110;
 
                 // LUT4 configured as 1-bit adder with CI=const
                 adder_lut4 #(
                     .LUT(INIT),
                     .IN2_IS_CIN(1'b0)
                 ) lut_ci_adder (
-                    .in({AA[i], BB[i], 1'b0, 1'b0}), 
+                    .in({AA[i], BB[i], 1'b1, 1'b1}),
                     .cin(), 
                     .lut4_out(Y[i]), 
                     .cout(ci)
@@ -68,10 +68,10 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
                 // LUT4 configured as passthrough to drive CI of the next stage
                 adder_lut4 #(
-                    .LUT(16'b1100_0000_0000_0011),
+                    .LUT(16'b0000_0000_0000_1100),
                     .IN2_IS_CIN(1'b0)
                 ) lut_ci (
-                    .in({1'b0,CI,1'b0,1'b0}), 
+                    .in({1'b1, CI, 1'b1, 1'b1}),
                     .cin(), 
                     .lut4_out(), 
                     .cout(ci)
@@ -92,10 +92,10 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             
             // LUT4 configured as full 1-bit adder
             adder_lut4 #(
-                    .LUT(16'b0110_1001_0110_0001),
+                    .LUT(16'b1001_0110_0110_1000),
                     .IN2_IS_CIN(1'b1)
                 ) lut_adder (
-                    .in({AA[i], BB[i], 1'b0, 1'b0}),
+                    .in({AA[i], BB[i], 1'b1, 1'b1}),
                     .cin(ci), 
                     .lut4_out(Y[i]), 
                     .cout(co)
@@ -116,7 +116,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                     .LUT(16'b0000_1111_0000_1111),
                     .IN2_IS_CIN(1'b1)
                 ) lut_co (
-                    .in({1'b0, co, 1'b0, 1'b0}),
+                    .in({1'b1, co, 1'b1, 1'b1}),
                     .cin(co),
                     .lut4_out(C[i]),
                     .cout()

--- a/techlibs/quicklogic/qlf_k4n8_cells_sim.v
+++ b/techlibs/quicklogic/qlf_k4n8_cells_sim.v
@@ -14,15 +14,15 @@ module adder_lut4(
 
     // Output function
     wire [0:7] s1 = li[0] ?
-        {LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15]}:
-        {LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14]};
+        {LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14]}:
+        {LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15]};
 
-    wire [0:3] s2 = li[1] ? {s1[1], s1[3], s1[5], s1[7]} :
-                            {s1[0], s1[2], s1[4], s1[6]};
+    wire [0:3] s2 = li[1] ? {s1[0], s1[2], s1[4], s1[6]} : 
+                            {s1[1], s1[3], s1[5], s1[7]};
 
-    wire [0:1] s3 = li[2] ? {s2[1], s2[3]} : {s2[0], s2[2]};
+    wire [0:1] s3 = li[2] ? {s2[0], s2[2]} : {s2[1], s2[3]};
 
-    assign lut4_out = li[3] ? s3[1] : s3[0];
+    assign lut4_out = li[3] ? s3[0] : s3[1];
     
     // Carry out function
     assign cout = (s2[2]) ? cin : s2[3];
@@ -41,18 +41,18 @@ module frac_lut4(
 
     // Output function
     wire [0:7] s1 = li[0] ?
-        {LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15]}:
-        {LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14]};
+        {LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14]}:
+        {LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15]};
 
-    wire [0:3] s2 = li[1] ? {s1[1], s1[3], s1[5], s1[7]} :
-                            {s1[0], s1[2], s1[4], s1[6]};
+    wire [0:3] s2 = li[1] ? {s1[0], s1[2], s1[4], s1[6]} : 
+                            {s1[1], s1[3], s1[5], s1[7]};
 
-    wire [0:1] s3 = li[2] ? {s2[1], s2[3]} : {s2[0], s2[2]};
+    wire [0:1] s3 = li[2] ? {s2[0], s2[2]} : {s2[1], s2[3]};
 
     assign lut2_out[0] = s2[2];
     assign lut2_out[1] = s2[3];
 
-    assign  lut4_out = li[3] ? s3[1] : s3[0];
+    assign  lut4_out = li[3] ? s3[0] : s3[1];
 
 endmodule
 
@@ -67,4 +67,68 @@ module scff(
 
     always @(posedge clk)
         Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dff(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C)
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dffr(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C,
+    input R
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C or negedge R)
+        if (!R)
+            Q <= 1'b0;
+        else 
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module sh_dff(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C)
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dffs(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C,
+    input S
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C or negedge S)
+        if (!S)
+            Q <= 1'b1;
+        else
+            Q <= D;
 endmodule

--- a/techlibs/quicklogic/qlf_k4n8_ffs_map.v
+++ b/techlibs/quicklogic/qlf_k4n8_ffs_map.v
@@ -1,0 +1,78 @@
+module \$_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C));
+endmodule
+
+module \$_DFF_PN0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(R));
+endmodule
+
+module \$_DFF_PP0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(!R));
+endmodule
+
+module \$_DFF_PN1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffs _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .S(R));
+endmodule
+
+module \$_DFF_PP1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffs _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .S(!R));
+endmodule
+
+module \$__SHREG_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+
+    parameter DEPTH = 2;
+    reg [DEPTH-2:0] q;
+    genvar i;
+    generate for (i = 0; i < DEPTH; i = i + 1) begin: slice
+
+
+        // First in chain
+        generate if (i == 0) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(q[i]),
+                    .D(D),
+                    .C(C)
+                );
+        end endgenerate
+        // Middle in chain
+        generate if (i > 0 && i != DEPTH-1) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(q[i]),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+        // Last in chain
+        generate if (i == DEPTH-1) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(Q),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+   end: slice
+   endgenerate
+
+endmodule

--- a/techlibs/quicklogic/qlf_k6n10_arith_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_arith_map.v
@@ -55,5 +55,6 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 	     );
 	   end
 	   endgenerate
+	assign X = AA ^ BB;
 endmodule
 

--- a/techlibs/quicklogic/qlf_k6n10_arith_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_arith_map.v
@@ -1,0 +1,114 @@
+(* techmap_celltype = "$alu" *)
+module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
+    parameter A_SIGNED = 0;
+    parameter B_SIGNED = 0;
+    parameter A_WIDTH  = 1;
+    parameter B_WIDTH  = 1;
+    parameter Y_WIDTH  = 1;
+
+    parameter _TECHMAP_CONSTMSK_CI_ = 0;
+    parameter _TECHMAP_CONSTVAL_CI_ = 0;
+
+    (* force_downto *)
+    input [A_WIDTH-1:0] A;
+    (* force_downto *)
+    input [B_WIDTH-1:0] B;
+    (* force_downto *)
+    output [Y_WIDTH-1:0] X, Y;
+
+    input CI, BI;
+    (* force_downto *)
+    output [Y_WIDTH-1:0] CO;
+
+    wire _TECHMAP_FAIL_ = Y_WIDTH <= 2;
+
+    (* force_downto *)
+    wire [Y_WIDTH-1:0] A_buf, B_buf;
+    \$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+    \$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+    (* force_downto *)
+    wire [Y_WIDTH-1:0] AA = A_buf;
+    (* force_downto *)
+    wire [Y_WIDTH-1:0] BB = BI ? ~B_buf : B_buf;
+    (* force_downto *)
+    wire [Y_WIDTH-1:0] C;
+
+    assign CO = C[Y_WIDTH-1];
+
+    genvar i;
+    generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
+
+        wire ci;
+        wire co;
+
+        // First in chain
+        generate if (i == 0) begin
+
+            // CI connected to a constant
+            if (_TECHMAP_CONSTMSK_CI_ == 1) begin
+
+		adder adder_ci(
+			.a(AA[i]),
+			.b(BB[i]),
+			.cin(),
+			.cout(ci),
+			.sumout(Y[i]));
+
+            // CI connected to a non-const driver
+            end else begin
+
+		adder adder_ci_only(
+			.a(1'b0),
+			.b(1'b0),
+			.cin(),
+			.cout(ci),
+			.sumout());
+            end
+
+        // Not first in chain
+        end else begin
+            assign ci = C[i-1];
+
+        end endgenerate
+
+        // ....................................................
+
+        // Single 1-bit adder, mid-chain adder or non-const CI
+        // adder
+        generate if ((i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) || (i > 0)) begin
+
+		adder adder_inst(
+			.a(AA[i]),
+			.b(BB[i]),
+			.cin(ci),
+			.cout(co),
+			.sumout(Y[i]));
+        end else begin
+            assign co = ci;
+
+        end endgenerate
+
+        // ....................................................
+
+        // Last in chain
+        generate if (i == Y_WIDTH-1) begin
+
+		adder adder_ci(
+			.a(1'b0),
+			.b(co),
+			.cin(co),
+			.cout(),
+			.sumout(C[i]));
+        // Not last in chain
+        end else begin
+            assign C[i] = co;
+
+        end endgenerate
+
+    end: slice	  
+    endgenerate
+
+    /* End implementation */
+    assign X = AA ^ BB;
+endmodule

--- a/techlibs/quicklogic/qlf_k6n10_arith_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_arith_map.v
@@ -1,114 +1,59 @@
+//////////////////////////
+//      arithmetic      //
+//////////////////////////
+
 (* techmap_celltype = "$alu" *)
 module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
-    parameter A_SIGNED = 0;
-    parameter B_SIGNED = 0;
-    parameter A_WIDTH  = 1;
-    parameter B_WIDTH  = 1;
-    parameter Y_WIDTH  = 1;
 
-    parameter _TECHMAP_CONSTMSK_CI_ = 0;
-    parameter _TECHMAP_CONSTVAL_CI_ = 0;
+	parameter A_SIGNED = 0;
+	parameter B_SIGNED = 0;
+	parameter A_WIDTH = 1;
+	parameter B_WIDTH = 1;
+	parameter Y_WIDTH = 1;
 
-    (* force_downto *)
-    input [A_WIDTH-1:0] A;
-    (* force_downto *)
-    input [B_WIDTH-1:0] B;
-    (* force_downto *)
-    output [Y_WIDTH-1:0] X, Y;
+	input [A_WIDTH-1:0] A;
+	input [B_WIDTH-1:0] B;
+	output [Y_WIDTH:0] X, Y;
 
-    input CI, BI;
-    (* force_downto *)
-    output [Y_WIDTH-1:0] CO;
+	input CI, BI;
+	output [Y_WIDTH:0] CO;
 
-    wire _TECHMAP_FAIL_ = Y_WIDTH <= 2;
+	wire [Y_WIDTH-1:0] AA, BB;
+	wire [1024:0] _TECHMAP_DO_ = "splitnets CARRY; clean";
 
-    (* force_downto *)
-    wire [Y_WIDTH-1:0] A_buf, B_buf;
-    \$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
-    \$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+	generate
+		if (A_SIGNED && B_SIGNED) begin:BLOCK1
+			assign AA = $signed(A), BB = BI ? ~$signed(B) : $signed(B);
+		end else begin:BLOCK2
+			assign AA = $unsigned(A), BB = BI ? ~$unsigned(B) : $unsigned(B);
+		end
+	endgenerate
 
-    (* force_downto *)
-    wire [Y_WIDTH-1:0] AA = A_buf;
-    (* force_downto *)
-    wire [Y_WIDTH-1:0] BB = BI ? ~B_buf : B_buf;
-    (* force_downto *)
-    wire [Y_WIDTH-1:0] C;
+	   wire [Y_WIDTH: 0 ] CARRY;
+	   assign CARRY[0] = CI;
 
-    assign CO = C[Y_WIDTH-1];
+	   genvar i;
+	   generate for (i = 0; i < Y_WIDTH - 1; i = i+1) begin:gen3
+	     adder my_adder (
+	       .cin		(CARRY[i]),
+	       .cout	(CARRY[i+1]),
+	       .a		(AA[i]),
+	       .b		(BB[i]),
+	       .sumout	(Y[i])
+	     );
+	   end endgenerate
 
-    genvar i;
-    generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
-
-        wire ci;
-        wire co;
-
-        // First in chain
-        generate if (i == 0) begin
-
-            // CI connected to a constant
-            if (_TECHMAP_CONSTMSK_CI_ == 1) begin
-
-		adder adder_ci(
-			.a(AA[i]),
-			.b(BB[i]),
-			.cin(),
-			.cout(ci),
-			.sumout(Y[i]));
-
-            // CI connected to a non-const driver
-            end else begin
-
-		adder adder_ci_only(
-			.a(1'b0),
-			.b(1'b0),
-			.cin(),
-			.cout(ci),
-			.sumout());
-            end
-
-        // Not first in chain
-        end else begin
-            assign ci = C[i-1];
-
-        end endgenerate
-
-        // ....................................................
-
-        // Single 1-bit adder, mid-chain adder or non-const CI
-        // adder
-        generate if ((i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) || (i > 0)) begin
-
-		adder adder_inst(
-			.a(AA[i]),
-			.b(BB[i]),
-			.cin(ci),
-			.cout(co),
-			.sumout(Y[i]));
-        end else begin
-            assign co = ci;
-
-        end endgenerate
-
-        // ....................................................
-
-        // Last in chain
-        generate if (i == Y_WIDTH-1) begin
-
-		adder adder_ci(
-			.a(1'b0),
-			.b(co),
-			.cin(co),
-			.cout(),
-			.sumout(C[i]));
-        // Not last in chain
-        end else begin
-            assign C[i] = co;
-
-        end endgenerate
-
-    end: slice	  
-    endgenerate
-
-    /* End implementation */
-    assign X = AA ^ BB;
+	   generate if ((Y_WIDTH -1) % 20 == 0) begin:gen4
+	     assign Y[Y_WIDTH-1] = CARRY[Y_WIDTH-1];
+	   end else begin:gen5
+	     adder my_adder (
+	       .cin		(CARRY[Y_WIDTH - 1]),
+	       .cout	(CARRY[Y_WIDTH]),
+	       .a		(1'b0),
+	       .b		(1'b0),
+	       .sumout	(Y[Y_WIDTH -1])
+	     );
+	   end
+	   endgenerate
 endmodule
+

--- a/techlibs/quicklogic/qlf_k6n10_brams.txt
+++ b/techlibs/quicklogic/qlf_k6n10_brams.txt
@@ -1,0 +1,100 @@
+bram $__QLF_RAM16K_M0
+  init 1
+  abits 9
+  dbits 32
+  groups 2
+  ports  1  1
+  wrmode 0  1
+  enable 1 16
+  transp 0  0
+  clocks 2  3
+  clkpol 2  3
+endbram
+
+bram $__QLF_RAM16K_M12
+  init 1
+  abits  10 @M1
+  dbits  16 @M1
+  abits 11 @M2
+  dbits  8 @M2
+  groups 2
+  ports  1 1
+  wrmode 0 1
+  enable 1 1
+  transp 0 0
+  clocks 2 3
+  clkpol 2 3
+endbram
+
+# The syn_* attributes are described in:
+# https://www.latticesemi.com/-/media/LatticeSemi/Documents/Tutorials/AK/LatticeDiamondTutorial311.ashx
+attr_icase 1
+
+match $__QLF_RAM16K_M0
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
+  attribute !rom_block
+  attribute !logic_block
+  min efficiency 2
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M0
+  # explicitly requested RAM
+  attribute syn_ramstyle=block_ram ram_block
+  attribute !syn_romstyle
+  attribute !rom_block
+  attribute !logic_block
+  min wports 1
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M0
+  # explicitly requested ROM
+  attribute syn_romstyle=ebr rom_block
+  attribute !syn_ramstyle
+  attribute !ram_block
+  attribute !logic_block
+  max wports 0
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M12
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
+  attribute !rom_block
+  attribute !logic_block
+  min efficiency 2
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M12
+  # explicitly requested RAM
+  attribute syn_ramstyle=block_ram ram_block
+  attribute !syn_romstyle
+  attribute !rom_block
+  attribute !logic_block
+  min wports 1
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M12
+  # explicitly requested ROM
+  attribute syn_romstyle=ebr rom_block
+  attribute !syn_ramstyle
+  attribute !ram_block
+  attribute !logic_block
+  max wports 0
+  make_transp
+endmatch
+
+

--- a/techlibs/quicklogic/qlf_k6n10_brams.txt
+++ b/techlibs/quicklogic/qlf_k6n10_brams.txt
@@ -7,7 +7,7 @@ bram $__QLF_RAM16K_M0
   wrmode 0 1
   enable 1 1
   transp 0  0
-  clocks 2  3
+  clocks 1  1
   clkpol 1  1
 endbram
 
@@ -20,7 +20,7 @@ bram $__QLF_RAM16K_M1
   wrmode 0 1
   enable 1 1
   transp 0 0
-  clocks 2 3
+  clocks 1 1
   clkpol 1 1
 endbram
 
@@ -33,7 +33,7 @@ bram $__QLF_RAM16K_M2
   wrmode 0 1
   enable 1 1
   transp 0 0
-  clocks 2 3
+  clocks 1 1
   clkpol 1 1
 endbram
 
@@ -46,7 +46,7 @@ bram $__QLF_RAM16K_M3
   wrmode 0 1
   enable 1 1
   transp 0 0
-  clocks 2 3
+  clocks 1 1
   clkpol 1 1
 endbram
 

--- a/techlibs/quicklogic/qlf_k6n10_brams.txt
+++ b/techlibs/quicklogic/qlf_k6n10_brams.txt
@@ -1,30 +1,55 @@
 bram $__QLF_RAM16K_M0
   init 1
-  abits 9
+  abits 8
   dbits 32
   groups 2
   ports  1  1
-  wrmode 0  1
-  enable 1 16
+  wrmode 0 1
+  enable 1 1
   transp 0  0
   clocks 2  3
-  clkpol 2  3
+  clkpol 1  1
 endbram
 
-bram $__QLF_RAM16K_M12
+bram $__QLF_RAM16K_M1
   init 1
-  abits  10 @M1
-  dbits  16 @M1
-  abits 11 @M2
-  dbits  8 @M2
+  abits  9
+  dbits  32
   groups 2
   ports  1 1
   wrmode 0 1
   enable 1 1
   transp 0 0
   clocks 2 3
-  clkpol 2 3
+  clkpol 1 1
 endbram
+
+bram $__QLF_RAM16K_M2
+  init 1
+  abits  10
+  dbits  32
+  groups 2
+  ports  1 1
+  wrmode 0 1
+  enable 1 1
+  transp 0 0
+  clocks 2 3
+  clkpol 1 1
+endbram
+
+bram $__QLF_RAM16K_M3
+  init 1
+  abits 11
+  dbits  32
+  groups 2
+  ports  1 1
+  wrmode 0 1
+  enable 1 1
+  transp 0 0
+  clocks 2 3
+  clkpol 1 1
+endbram
+
 
 # The syn_* attributes are described in:
 # https://www.latticesemi.com/-/media/LatticeSemi/Documents/Tutorials/AK/LatticeDiamondTutorial311.ashx
@@ -37,34 +62,24 @@ match $__QLF_RAM16K_M0
   attribute !ram_block
   attribute !rom_block
   attribute !logic_block
-  min efficiency 2
+  min dbits 17
   make_transp
-  or_next_if_better
 endmatch
 
-match $__QLF_RAM16K_M0
-  # explicitly requested RAM
-  attribute syn_ramstyle=block_ram ram_block
-  attribute !syn_romstyle
+
+match $__QLF_RAM16K_M1
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
   attribute !rom_block
   attribute !logic_block
-  min wports 1
+  min dbits 9
   make_transp
   or_next_if_better
 endmatch
 
-match $__QLF_RAM16K_M0
-  # explicitly requested ROM
-  attribute syn_romstyle=ebr rom_block
-  attribute !syn_ramstyle
-  attribute !ram_block
-  attribute !logic_block
-  max wports 0
-  make_transp
-  or_next_if_better
-endmatch
-
-match $__QLF_RAM16K_M12
+match $__QLF_RAM16K_M1
   # implicitly requested RAM or ROM
   attribute !syn_ramstyle syn_ramstyle=auto
   attribute !syn_romstyle syn_romstyle=auto
@@ -73,28 +88,52 @@ match $__QLF_RAM16K_M12
   attribute !logic_block
   min efficiency 2
   make_transp
-  or_next_if_better
 endmatch
 
-match $__QLF_RAM16K_M12
-  # explicitly requested RAM
-  attribute syn_ramstyle=block_ram ram_block
-  attribute !syn_romstyle
+
+match $__QLF_RAM16K_M2
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
   attribute !rom_block
   attribute !logic_block
-  min wports 1
+  min dbits 5
   make_transp
   or_next_if_better
 endmatch
 
-match $__QLF_RAM16K_M12
-  # explicitly requested ROM
-  attribute syn_romstyle=ebr rom_block
-  attribute !syn_ramstyle
+match $__QLF_RAM16K_M2
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
   attribute !ram_block
+  attribute !rom_block
   attribute !logic_block
-  max wports 0
+  min efficiency 2
   make_transp
 endmatch
 
+match $__QLF_RAM16K_M3
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
+  attribute !rom_block
+  attribute !logic_block
+  max dbits 4
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_RAM16K_M3
+  # implicitly requested RAM or ROM
+  attribute !syn_ramstyle syn_ramstyle=auto
+  attribute !syn_romstyle syn_romstyle=auto
+  attribute !ram_block
+  attribute !rom_block
+  attribute !logic_block
+  min efficiency 2
+  make_transp
+endmatch
 

--- a/techlibs/quicklogic/qlf_k6n10_brams_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_brams_map.v
@@ -28,8 +28,7 @@ endmodule
 
 
 module \$__QLF_RAM16K_M0 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
-	parameter [0:0] CLKPOL2 = 1;
-	parameter [0:0] CLKPOL3 = 1;
+
 
 	parameter [4095:0] INIT = 4096'bx;
 
@@ -64,8 +63,6 @@ endmodule
 
 module \$__QLF_RAM16K_M1 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
-	parameter [0:0] CLKPOL2 = 1;
-	parameter [0:0] CLKPOL3 = 1;
 
 	parameter [4095:0] INIT = 4096'bx;
 
@@ -109,8 +106,6 @@ endmodule
 
 module \$__QLF_RAM16K_M2 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
-	parameter [0:0] CLKPOL2 = 1;
-	parameter [0:0] CLKPOL3 = 1;
 
 	parameter [4095:0] INIT = 4096'bx;
 
@@ -157,9 +152,6 @@ module \$__QLF_RAM16K_M2 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN
 endmodule
 
 module \$__QLF_RAM16K_M3 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
-
-	parameter [0:0] CLKPOL2 = 1;
-	parameter [0:0] CLKPOL3 = 1;
 
 	parameter [4095:0] INIT = 4096'bx;
 

--- a/techlibs/quicklogic/qlf_k6n10_brams_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_brams_map.v
@@ -27,13 +27,12 @@ module \$__QLF_RAM16K (
 endmodule
 
 
-module \$__QLF_RAM16K_M0 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+module \$__QLF_RAM16K_M0 (CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
 
 	parameter [4095:0] INIT = 4096'bx;
 
-	input CLK2;
-	input CLK3;
+	input CLK1;
 
 	input [8:0] A1ADDR;
 	output [31:0] A1DATA;
@@ -50,24 +49,23 @@ module \$__QLF_RAM16K_M0 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN
 		 _TECHMAP_REPLACE_ (
 		.RDATA(A1DATA),
 		.RADDR(A1ADDR),
-		.RCLK(CLK2),
+		.RCLK(CLK1),
 		.RE(A1EN),
 		.WDATA(B1DATA),
 		.WADDR(B1ADDR),
-		.WCLK(CLK3),
+		.WCLK(CLK1),
 		.WE(B1EN),
 		.WENB(WENB)
 	);
 endmodule
 
 
-module \$__QLF_RAM16K_M1 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+module \$__QLF_RAM16K_M1 (CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
 
 	parameter [4095:0] INIT = 4096'bx;
 
-	input CLK2;
-	input CLK3;
+	input CLK1;
 
 	input [9:0] A1ADDR;
 	output [31:0] A1DATA;
@@ -93,24 +91,23 @@ module \$__QLF_RAM16K_M1 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN
 		 _TECHMAP_REPLACE_ (
 		.RDATA(A1DATA),
 		.RADDR(A1ADDR),
-		.RCLK(CLK2),
+		.RCLK(CLK1),
 		.RE(A1EN),
 		.WDATA(WDATA),
 		.WADDR(B1ADDR[9:1]),
-		.WCLK(CLK3),
+		.WCLK(CLK1),
 		.WENB(WENB),
 		.WE(B1EN)
 	);
 
 endmodule
 
-module \$__QLF_RAM16K_M2 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+module \$__QLF_RAM16K_M2 (CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
 
 	parameter [4095:0] INIT = 4096'bx;
 
-	input CLK2;
-	input CLK3;
+	input CLK1;
 
 	input [10:0] A1ADDR;
 	output [31:0] A1DATA;
@@ -140,23 +137,22 @@ module \$__QLF_RAM16K_M2 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN
 		 _TECHMAP_REPLACE_ (
 		.RDATA(A1DATA),
 		.RADDR(A1ADDR),
-		.RCLK(CLK2),
+		.RCLK(CLK1),
 		.RE(A1EN),
 		.WDATA(B1DATA),
 		.WADDR(B1ADDR[10:2]),
-		.WCLK(CLK3),
+		.WCLK(CLK1),
 		.WENB(WENB),
 		.WE(B1EN)
 	);
 
 endmodule
 
-module \$__QLF_RAM16K_M3 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+module \$__QLF_RAM16K_M3 (CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 
 	parameter [4095:0] INIT = 4096'bx;
 
-	input CLK2;
-	input CLK3;
+	input CLK1;
 
 	input [11:0] A1ADDR;
 	output [31:0] A1DATA;
@@ -190,11 +186,11 @@ module \$__QLF_RAM16K_M3 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN
 		 _TECHMAP_REPLACE_ (
 		.RDATA(A1DATA),
 		.RADDR(A1ADDR),
-		.RCLK(CLK2),
+		.RCLK(CLK1),
 		.RE(A1EN),
 		.WDATA(B1DATA),
 		.WADDR(B1ADDR[11:3]),
-		.WCLK(CLK3),
+		.WCLK(CLK1),
 		.WENB(WENB),
 		.WE(B1EN)
 	);

--- a/techlibs/quicklogic/qlf_k6n10_brams_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_brams_map.v
@@ -1,0 +1,142 @@
+
+module \$__QLF_RAM16K (
+	output [31:0] RDATA,
+	input         RCLK, RE,
+	input  [11:0] RADDR,
+	input         WCLK, WE,
+	input  [11:0] WADDR,
+	input  [31:0] WDATA
+);
+
+	generate
+			dual_port_ram #()
+				 _TECHMAP_REPLACE_ (
+				.d_out(RDATA),
+				.clk (RCLK ),
+				.ren   (RE   ),
+				.raddr(RADDR),
+				.wen   (WE   ),
+				.waddr(WADDR),
+				.d_in(WDATA)
+				);
+	endgenerate
+
+endmodule
+
+
+module \$__QLF_RAM16K_M0 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+	parameter [0:0] CLKPOL2 = 1;
+	parameter [0:0] CLKPOL3 = 1;
+
+	parameter [4095:0] INIT = 4096'bx;
+
+	input CLK2;
+	input CLK3;
+
+	input [7:0] A1ADDR;
+	output [31:0] A1DATA;
+	input A1EN;
+
+	input [7:0] B1ADDR;
+	input [31:0] B1DATA;
+	input [15:0] B1EN;
+
+	wire [10:0] A1ADDR_11 = A1ADDR;
+	wire [10:0] B1ADDR_11 = B1ADDR;
+
+	\$__QLF_RAM16K #()
+		 _TECHMAP_REPLACE_ (
+		.RDATA(A1DATA),
+		.RADDR(A1ADDR_11),
+		.RCLK(CLK2),
+		.RE(1'b1),
+		.WDATA(B1DATA),
+		.WADDR(B1ADDR_11),
+		.WCLK(CLK3),
+		.WE(1'b1)
+	);
+endmodule
+
+// TODO: Test with corner case
+
+module \$__QLF_RAM16K_M12 (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+	parameter CFG_ABITS = 10;
+	parameter CFG_DBITS = 16;
+
+	parameter [0:0] CLKPOL2 = 1;
+	parameter [0:0] CLKPOL3 = 1;
+
+	parameter [4095:0] INIT = 4096'bx;
+
+/*	localparam MODE =
+		CFG_ABITS ==  9 ? 1 :
+		CFG_ABITS == 10 ? 1 :
+		CFG_ABITS == 11 ? 2 : 'bx;*/
+	localparam MODE =
+		CFG_ABITS == 10 ? 1 :
+		CFG_ABITS == 11 ? 2 : 'bx;
+
+	input CLK2;
+	input CLK3;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input B1EN;
+
+	wire [10:0] A1ADDR_11 = A1ADDR;
+	wire [10:0] B1ADDR_11 = B1ADDR;
+
+	wire [15:0] A1DATA_16, B1DATA_16;
+
+/*	generate
+		if (MODE == 1) begin
+			assign A1DATA = {A1DATA_16[14], A1DATA_16[12], A1DATA_16[10], A1DATA_16[ 8],
+			                 A1DATA_16[ 6], A1DATA_16[ 4], A1DATA_16[ 2], A1DATA_16[ 0]};
+			assign {B1DATA_16[14], B1DATA_16[12], B1DATA_16[10], B1DATA_16[ 8],
+			        B1DATA_16[ 6], B1DATA_16[ 4], B1DATA_16[ 2], B1DATA_16[ 0]} = B1DATA;
+		end
+		if (MODE == 2) begin
+			assign A1DATA = {A1DATA_16[13], A1DATA_16[9], A1DATA_16[5], A1DATA_16[1]};
+			assign {B1DATA_16[13], B1DATA_16[9], B1DATA_16[5], B1DATA_16[1]} = B1DATA;
+		end
+		if (MODE == 3) begin
+			assign A1DATA = {A1DATA_16[11], A1DATA_16[3]};
+			assign {B1DATA_16[11], B1DATA_16[3]} = B1DATA;
+		end
+	endgenerate*/
+	generate
+		if (MODE == 1) begin
+			assign A1DATA = {A1DATA_16[30], A1DATA_16[28], A1DATA_16[26], A1DATA_16[ 24],
+			                 A1DATA_16[ 22], A1DATA_16[ 20], A1DATA_16[ 18], A1DATA_16[ 16],
+					 A1DATA_16[14], A1DATA_16[12], A1DATA_16[10], A1DATA_16[ 8],
+			                 A1DATA_16[ 6], A1DATA_16[ 4], A1DATA_16[ 2], A1DATA_16[ 0]};					
+			assign {B1DATA_16[30], B1DATA_16[28], B1DATA_16[26], B1DATA_16[ 24],
+			        B1DATA_16[ 22], B1DATA_16[ 20], B1DATA_16[ 18], B1DATA_16[ 16],
+				B1DATA_16[14], B1DATA_16[12], B1DATA_16[10], B1DATA_16[ 8],
+			        B1DATA_16[ 6], B1DATA_16[ 4], B1DATA_16[ 2], B1DATA_16[ 0]} = B1DATA;			
+		end
+		if (MODE == 2) begin
+			assign A1DATA = {A1DATA_16[14], A1DATA_16[12], A1DATA_16[10], A1DATA_16[ 8],
+			                 A1DATA_16[ 6], A1DATA_16[ 4], A1DATA_16[ 2], A1DATA_16[ 0]};
+			assign {B1DATA_16[14], B1DATA_16[12], B1DATA_16[10], B1DATA_16[ 8],
+			        B1DATA_16[ 6], B1DATA_16[ 4], B1DATA_16[ 2], B1DATA_16[ 0]} = B1DATA;
+		end
+	endgenerate
+
+	\$__ICE40_RAM4K #()
+		 _TECHMAP_REPLACE_ (
+		.RDATA(A1DATA_16),
+		.RADDR(A1ADDR_11),
+		.RCLK(CLK2),
+		.RE(1'b1),
+		.WDATA(B1DATA_16),
+		.WADDR(B1ADDR_11),
+		.WCLK(CLK3),
+		.WE(1'b1)
+	);
+endmodule
+

--- a/techlibs/quicklogic/qlf_k6n10_cells_sim.v
+++ b/techlibs/quicklogic/qlf_k6n10_cells_sim.v
@@ -1,0 +1,131 @@
+(* abc9_box, lib_whitebox *)
+module adder(
+   output sumout,
+   output cout,
+   input a,
+   input b,
+   input cin
+);
+endmodule
+
+(* abc9_lut=1, lib_whitebox *)
+module frac_lut6(
+   input [0:5] in,
+   output [0:3] lut4_out,
+   output [0:1] lut5_out,
+   output lut6_out
+);
+    parameter [0:63] LUT = 0;
+    // Effective LUT input
+    wire [0:5] li = in;
+
+    // Output function
+    wire [0:31] s1 = li[0] ?
+	{LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15], 
+	 LUT[17], LUT[19], LUT[21], LUT[23], LUT[25], LUT[27], LUT[29], LUT[31],
+	 LUT[33], LUT[35], LUT[37], LUT[39], LUT[41], LUT[43], LUT[45], LUT[47],
+	 LUT[49], LUT[51], LUT[53], LUT[55], LUT[57], LUT[59], LUT[61], LUT[63]}:
+	{LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14], 
+	 LUT[16], LUT[18], LUT[20], LUT[22], LUT[24], LUT[26], LUT[28], LUT[30],
+	 LUT[32], LUT[34], LUT[36], LUT[38], LUT[40], LUT[42], LUT[44], LUT[46],
+	 LUT[48], LUT[50], LUT[52], LUT[54], LUT[56], LUT[58], LUT[60], LUT[62]};
+
+    wire [0:15] s2 = li[1] ?
+	{s1[1], s1[3], s1[5], s1[7], s1[9], s1[11], s1[13], s1[15],
+	 s1[17], s1[19], s1[21], s1[23], s1[25], s1[27], s1[29], s1[31]}:
+	{s1[0], s1[2], s1[4], s1[6], s1[8], s1[10], s1[12], s1[14],
+	 s1[16], s1[18], s1[20], s1[22], s1[24], s1[26], s1[28], s1[30]};
+
+    wire [0:7] s3 = li[2] ?
+        {s2[1], s2[3], s2[5], s2[7], s2[9], s2[11], s2[13], s2[15]}:
+        {s2[0], s2[2], s2[4], s2[6], s2[8], s2[10], s2[12], s2[14]};
+
+    wire [0:3] s4 = li[3] ? {s3[1], s3[3], s3[5], s3[7]}:
+                            {s3[0], s3[2], s3[4], s3[6]};
+
+    wire [0:1] s5 = li[4] ? {s4[1], s4[3]} : {s4[0], s4[2]};
+
+   assign lut4_out[0] = s4[0];
+   assign lut4_out[1] = s4[1];
+   assign lut4_out[2] = s4[2];
+   assign lut4_out[3] = s4[3];
+
+   assign lut5_out[0] = s0[0];
+   assign lut5_out[1] = s5[1];
+
+   assign lut6_out = li[5] ? s5[1] : s5[0];
+
+endmodule
+
+(* abc9_box, lib_whitebox *)
+module dff (
+	output Q,
+	input C,D
+);
+	always @(posedge C)
+			Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module scff(
+    output reg Q,
+    input D,
+    input clk
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge clk)
+        Q <= D;
+endmodule
+
+module dual_port_ram (
+        input clk,
+        input wen,
+        input ren,
+        input[11:0] waddr,
+        input[11:0] raddr,
+        input[31:0] d_in,
+        output[31:0] d_out );
+
+                dual_port_sram memory_0 (
+                        .wclk           (clk),
+                        .wen            (wen),
+                        .waddr          (waddr),
+                        .data_in        (d_in),
+                        .rclk           (clk),
+                        .ren            (ren),
+                        .raddr          (raddr),
+                        .d_out          (d_out) );
+
+endmodule
+
+module dual_port_sram (
+        input wclk,
+        input wen,
+        input[11:0] waddr,
+        input[31:0] data_in,
+        input rclk,
+        input ren,
+        input[11:0] raddr,
+        output[31:0] d_out );
+
+        reg[31:0] ram[4095:0];
+        reg[31:0] internal;
+
+        assign d_out = internal;
+
+        always @(posedge wclk) begin
+                if(wen) begin
+                        ram[waddr] <= data_in;
+                end
+        end
+
+	always @(posedge rclk) begin
+                if(ren) begin
+                        internal <= ram[raddr];
+                end
+        end
+
+endmodule
+

--- a/techlibs/quicklogic/qlf_k6n10_cells_sim.v
+++ b/techlibs/quicklogic/qlf_k6n10_cells_sim.v
@@ -128,8 +128,8 @@ module _dual_port_sram (
 
         // MODE 0:  512 x 32
         // MODE 1:  1024 x 16
-        // MODE 2: 1024 x 8
-        // MODE 3: 2048 x 4
+        // MODE 2: 2048 x 8
+        // MODE 3: 4096 x 4
         
         integer i;
         reg[31:0] ram[512:0];

--- a/techlibs/quicklogic/qlf_k6n10_cells_sim.v
+++ b/techlibs/quicklogic/qlf_k6n10_cells_sim.v
@@ -76,22 +76,6 @@ module dff(
             Q <= D;
 endmodule
 
-module dffr(
-    output reg Q,
-    input D,
-    (* clkbuf_sink *)
-    input C,
-    input R
-);
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
-
-    always @(posedge C or negedge R)
-        if (!R)
-            Q <= 1'b0;
-        else 
-            Q <= D;
-endmodule
 
 (* abc9_flop, lib_whitebox *)
 module scff(

--- a/techlibs/quicklogic/qlf_k6n10_cells_sim.v
+++ b/techlibs/quicklogic/qlf_k6n10_cells_sim.v
@@ -6,7 +6,12 @@ module adder(
    input b,
    input cin
 );
+	assign sumout = a ^ b ^ cin;
+	assign cout = (a & b) | ((a | b) & cin);
+
 endmodule
+
+
 
 (* abc9_lut=1, lib_whitebox *)
 module frac_lut6(
@@ -21,29 +26,29 @@ module frac_lut6(
 
     // Output function
     wire [0:31] s1 = li[0] ?
-	{LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15], 
-	 LUT[17], LUT[19], LUT[21], LUT[23], LUT[25], LUT[27], LUT[29], LUT[31],
-	 LUT[33], LUT[35], LUT[37], LUT[39], LUT[41], LUT[43], LUT[45], LUT[47],
-	 LUT[49], LUT[51], LUT[53], LUT[55], LUT[57], LUT[59], LUT[61], LUT[63]}:
 	{LUT[0], LUT[2], LUT[4], LUT[6], LUT[8], LUT[10], LUT[12], LUT[14], 
 	 LUT[16], LUT[18], LUT[20], LUT[22], LUT[24], LUT[26], LUT[28], LUT[30],
 	 LUT[32], LUT[34], LUT[36], LUT[38], LUT[40], LUT[42], LUT[44], LUT[46],
-	 LUT[48], LUT[50], LUT[52], LUT[54], LUT[56], LUT[58], LUT[60], LUT[62]};
+	 LUT[48], LUT[50], LUT[52], LUT[54], LUT[56], LUT[58], LUT[60], LUT[62]}:
+	{LUT[1], LUT[3], LUT[5], LUT[7], LUT[9], LUT[11], LUT[13], LUT[15], 
+	 LUT[17], LUT[19], LUT[21], LUT[23], LUT[25], LUT[27], LUT[29], LUT[31],
+	 LUT[33], LUT[35], LUT[37], LUT[39], LUT[41], LUT[43], LUT[45], LUT[47],
+	 LUT[49], LUT[51], LUT[53], LUT[55], LUT[57], LUT[59], LUT[61], LUT[63]};
 
     wire [0:15] s2 = li[1] ?
-	{s1[1], s1[3], s1[5], s1[7], s1[9], s1[11], s1[13], s1[15],
-	 s1[17], s1[19], s1[21], s1[23], s1[25], s1[27], s1[29], s1[31]}:
 	{s1[0], s1[2], s1[4], s1[6], s1[8], s1[10], s1[12], s1[14],
-	 s1[16], s1[18], s1[20], s1[22], s1[24], s1[26], s1[28], s1[30]};
+	 s1[16], s1[18], s1[20], s1[22], s1[24], s1[26], s1[28], s1[30]}:
+	{s1[1], s1[3], s1[5], s1[7], s1[9], s1[11], s1[13], s1[15],
+	 s1[17], s1[19], s1[21], s1[23], s1[25], s1[27], s1[29], s1[31]};
 
     wire [0:7] s3 = li[2] ?
-        {s2[1], s2[3], s2[5], s2[7], s2[9], s2[11], s2[13], s2[15]}:
-        {s2[0], s2[2], s2[4], s2[6], s2[8], s2[10], s2[12], s2[14]};
+        {s2[0], s2[2], s2[4], s2[6], s2[8], s2[10], s2[12], s2[14]}:
+        {s2[1], s2[3], s2[5], s2[7], s2[9], s2[11], s2[13], s2[15]};
 
-    wire [0:3] s4 = li[3] ? {s3[1], s3[3], s3[5], s3[7]}:
-                            {s3[0], s3[2], s3[4], s3[6]};
+    wire [0:3] s4 = li[3] ? {s3[0], s3[2], s3[4], s3[6]}:
+			    {s3[1], s3[3], s3[5], s3[7]};
 
-    wire [0:1] s5 = li[4] ? {s4[1], s4[3]} : {s4[0], s4[2]};
+    wire [0:1] s5 = li[4] ? {s4[0], s4[2]} : {s4[1], s4[3]};
 
    assign lut4_out[0] = s4[0];
    assign lut4_out[1] = s4[1];
@@ -53,17 +58,39 @@ module frac_lut6(
    assign lut5_out[0] = s0[0];
    assign lut5_out[1] = s5[1];
 
-   assign lut6_out = li[5] ? s5[1] : s5[0];
+   assign lut6_out = li[5] ? s5[0] : s5[1];
 
 endmodule
 
-(* abc9_box, lib_whitebox *)
-module dff (
-	output Q,
-	input C,D
+(* abc9_flop, lib_whitebox *)
+module dff(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C
 );
-	always @(posedge C)
-			Q <= D;
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C)
+            Q <= D;
+endmodule
+
+module dffr(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C,
+    input R
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C or negedge R)
+        if (!R)
+            Q <= 1'b0;
+        else 
+            Q <= D;
 endmodule
 
 (* abc9_flop, lib_whitebox *)
@@ -79,53 +106,107 @@ module scff(
         Q <= D;
 endmodule
 
-module dual_port_ram (
-        input clk,
+
+module DP_RAM16K (
+        input rclk, 
+	input wclk,
         input wen,
         input ren,
-        input[11:0] waddr,
-        input[11:0] raddr,
+        input[8:0] waddr,
+        input[8:0] raddr,
         input[31:0] d_in,
+	input[31:0] wenb,
         output[31:0] d_out );
 
-                dual_port_sram memory_0 (
-                        .wclk           (clk),
+                _dual_port_sram memory_0 (
+                        .wclk           (wclk),
                         .wen            (wen),
                         .waddr          (waddr),
                         .data_in        (d_in),
-                        .rclk           (clk),
+                        .rclk           (rclk),
                         .ren            (ren),
                         .raddr          (raddr),
+			.wenb		(wenb),
                         .d_out          (d_out) );
 
 endmodule
 
-module dual_port_sram (
+module _dual_port_sram (
         input wclk,
         input wen,
-        input[11:0] waddr,
+        input[8:0] waddr,
         input[31:0] data_in,
         input rclk,
         input ren,
-        input[11:0] raddr,
+        input[8:0] raddr,
+	    input[31:0] wenb,
         output[31:0] d_out );
 
-        reg[31:0] ram[4095:0];
+        // MODE 0:  512 x 32
+        // MODE 1:  1024 x 16
+        // MODE 2: 1024 x 8
+        // MODE 3: 2048 x 4
+        
+        integer i;
+        reg[31:0] ram[512:0];
         reg[31:0] internal;
+        // The memory is self initialised
+        
+        	initial begin
+                for (i=0;i<=512;i=i+1)
+                begin
+                    ram[i] = 0;
+                end
+                internal = 31'b0; 
+	        end
+        
+        
+	    wire [31:0] WMASK;
 
         assign d_out = internal;
+	    assign WMASK = wenb;
 
         always @(posedge wclk) begin
-                if(wen) begin
-                        ram[waddr] <= data_in;
+                if(!wen) begin
+			if (WMASK[ 0]) ram[waddr][ 0] <= data_in[ 0];
+			if (WMASK[ 1]) ram[waddr][ 1] <= data_in[ 1];
+			if (WMASK[ 2]) ram[waddr][ 2] <= data_in[ 2];
+			if (WMASK[ 3]) ram[waddr][ 3] <= data_in[ 3];
+			if (WMASK[ 4]) ram[waddr][ 4] <= data_in[ 4];
+			if (WMASK[ 5]) ram[waddr][ 5] <= data_in[ 5];
+			if (WMASK[ 6]) ram[waddr][ 6] <= data_in[ 6];
+			if (WMASK[ 7]) ram[waddr][ 7] <= data_in[ 7];
+			if (WMASK[ 8]) ram[waddr][ 8] <= data_in[ 8];
+			if (WMASK[ 9]) ram[waddr][ 9] <= data_in[ 9];
+			if (WMASK[10]) ram[waddr][10] <= data_in[10];
+			if (WMASK[11]) ram[waddr][11] <= data_in[11];
+			if (WMASK[12]) ram[waddr][12] <= data_in[12];
+			if (WMASK[13]) ram[waddr][13] <= data_in[13];
+			if (WMASK[14]) ram[waddr][14] <= data_in[14];
+			if (WMASK[15]) ram[waddr][15] <= data_in[15];
+			if (WMASK[16]) ram[waddr][16] <= data_in[16];
+			if (WMASK[17]) ram[waddr][17] <= data_in[17];
+			if (WMASK[18]) ram[waddr][18] <= data_in[18];
+			if (WMASK[19]) ram[waddr][19] <= data_in[19];
+			if (WMASK[20]) ram[waddr][20] <= data_in[20];
+			if (WMASK[21]) ram[waddr][21] <= data_in[21];
+			if (WMASK[22]) ram[waddr][22] <= data_in[22];
+			if (WMASK[23]) ram[waddr][23] <= data_in[23];
+			if (WMASK[24]) ram[waddr][24] <= data_in[24];
+			if (WMASK[25]) ram[waddr][25] <= data_in[25];
+			if (WMASK[26]) ram[waddr][26] <= data_in[26];
+			if (WMASK[27]) ram[waddr][27] <= data_in[27];
+			if (WMASK[28]) ram[waddr][28] <= data_in[28];
+			if (WMASK[29]) ram[waddr][29] <= data_in[29];
+			if (WMASK[30]) ram[waddr][30] <= data_in[30];
+			if (WMASK[31]) ram[waddr][31] <= data_in[31];
                 end
-        end
+       	end
 
 	always @(posedge rclk) begin
-                if(ren) begin
+                if(!ren) begin
                         internal <= ram[raddr];
                 end
         end
 
 endmodule
-

--- a/techlibs/quicklogic/qlf_k6n10_ff_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_ff_map.v
@@ -1,0 +1,1 @@
+module  \$_DFF_P_ (input D, C, output Q); dff  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C)); wire _TECHMAP_REMOVEINIT_Q_ = 1; endmodule

--- a/techlibs/quicklogic/qlf_k6n10_ff_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_ff_map.v
@@ -1,1 +1,0 @@
-module  \$_DFF_P_ (input D, C, output Q); dff  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C)); wire _TECHMAP_REMOVEINIT_Q_ = 1; endmodule

--- a/techlibs/quicklogic/qlf_k6n10_ffs_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_ffs_map.v
@@ -4,20 +4,3 @@ module \$_DFF_P_ (D, Q, C);
     output Q;
     dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C));
 endmodule
-
-module \$_DFF_PN0_ (D, Q, C, R);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(R));
-endmodule
-
-module \$_DFF_PP0_ (D, Q, C, R);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(!R));
-endmodule
-

--- a/techlibs/quicklogic/qlf_k6n10_ffs_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_ffs_map.v
@@ -1,0 +1,23 @@
+module \$_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C));
+endmodule
+
+module \$_DFF_PN0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(R));
+endmodule
+
+module \$_DFF_PP0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(!R));
+endmodule
+

--- a/techlibs/quicklogic/qlf_k6n10_lut_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_lut_map.v
@@ -1,0 +1,50 @@
+//TODO: Fix corner case where frac_lut6 fails to route when infered in mode n2_lut5
+
+/*`ifndef NO_LUT
+module \$lut (A, Y);
+    parameter WIDTH = 0;
+    parameter LUT = 0;
+
+    (* force_downto *)
+    input [WIDTH-1:0] A;
+    output Y;
+
+    generate
+    if (WIDTH == 1) begin
+	wire lut4_out;
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0],5'b0}));
+	assign Y = lut4_out[0];
+    end else
+    if (WIDTH == 2) begin
+	wire lut4_out;
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:1],4'b0}));
+	assign Y = lut4_out[0];
+    end else
+    if (WIDTH == 3) begin
+	wire lut4_out;
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:2],3'b0}));
+	assign Y = lut4_out[0];
+    end else
+    if (WIDTH == 4) begin
+	wire lut4_out;
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:3],2'b0}));
+	assign Y = lut4_out[0];
+    end else
+    if (WIDTH == 5) begin
+	wire lut5_out;
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut5_out(lut5_out),.in({A[0:4],1'b0}));
+	assign Y = lut5_out[0];
+    end else
+    if (WIDTH == 6) begin
+        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut6_out(Y),.in(A));
+
+    end else begin
+        wire _TECHMAP_FAIL_ = 1;
+    end
+    endgenerate
+
+endmodule
+`endif
+
+*/
+

--- a/techlibs/quicklogic/qlf_k6n10_lut_map.v
+++ b/techlibs/quicklogic/qlf_k6n10_lut_map.v
@@ -1,6 +1,4 @@
-//TODO: Fix corner case where frac_lut6 fails to route when infered in mode n2_lut5
-
-/*`ifndef NO_LUT
+`ifndef NO_LUT
 module \$lut (A, Y);
     parameter WIDTH = 0;
     parameter LUT = 0;
@@ -10,41 +8,16 @@ module \$lut (A, Y);
     output Y;
 
     generate
-    if (WIDTH == 1) begin
-	wire lut4_out;
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0],5'b0}));
-	assign Y = lut4_out[0];
-    end else
-    if (WIDTH == 2) begin
-	wire lut4_out;
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:1],4'b0}));
-	assign Y = lut4_out[0];
-    end else
-    if (WIDTH == 3) begin
-	wire lut4_out;
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:2],3'b0}));
-	assign Y = lut4_out[0];
-    end else
-    if (WIDTH == 4) begin
-	wire lut4_out;
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut4_out(lut4_out),.in({A[0:3],2'b0}));
-	assign Y = lut4_out[0];
-    end else
-    if (WIDTH == 5) begin
-	wire lut5_out;
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut5_out(lut5_out),.in({A[0:4],1'b0}));
-	assign Y = lut5_out[0];
-    end else
-    if (WIDTH == 6) begin
-        frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut6_out(Y),.in(A));
+	    if (WIDTH == 6) begin
+		frac_lut6 #(.LUT(LUT)) _TECHMAP_REPLACE_ (.lut6_out(Y),.in(A));
 
-    end else begin
-        wire _TECHMAP_FAIL_ = 1;
-    end
+	    end else begin
+		wire _TECHMAP_FAIL_ = 1;
+	    end
     endgenerate
 
 endmodule
 `endif
 
-*/
+
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -215,12 +215,13 @@ struct SynthQuickLogicPass : public ScriptPass {
         if (check_label("map_ffs")) {
 
 
-	    run("async2sync");
+//	    run("async2sync");
             std::string techMapArgs = " -map +/quicklogic/" + family + "_ff_map.v";
-	    run("techmap " + techMapArgs);
+
             if (family == "qlf_k4n8" || family == "qlf_k6n10" ) {
 		run(stringf("dfflegalize -cell $_DFF_?_ 0 -cell $_DLATCH_?_ x"));
 		}
+	    run("techmap " + techMapArgs);
             run("opt_expr -mux_undef");
             run("simplemap");
             run("opt_expr");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -41,7 +41,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         log("        run synthesis for the specified QuickLogic architecture\n");
         log("        generate the synthesis netlist for the specified family.\n");
         log("        supported values:\n");
-        log("        - qlf_k4n8: qlf_k4n8 \n");
+        log("        - qlf_k6n10: qlf_k6n10 \n");
         log("\n");
         log("    -no_abc_opt\n");
         log("        By default most of ABC logic optimization features is\n");
@@ -85,7 +85,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         blif_file = "";
         verilog_file = "";
         currmodule = "";
-        family = "qlf_k4n8";
+        family = "qlf_k6n10";
         inferAdder = true;
 	inferBram = true;
         abcOpt = true;
@@ -215,8 +215,8 @@ struct SynthQuickLogicPass : public ScriptPass {
 
             std::string techMapArgs = " -map +/quicklogic/" + family + "_ffs_map.v";
 
-            if (family == "qlf_k4n8" || family == "qlf_k6n10" ) {
-		run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFF_P?0_ 0 -cell $_DLATCH_P_ x");
+            if (family == "qlf_k6n10") {
+		run("dfflegalize -cell $_DFF_P_ 0 -cell $_DLATCH_P_ x");
 		}
 	    run("techmap " + techMapArgs);
             run("opt_expr -mux_undef");
@@ -229,12 +229,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("map_luts")) {
 	 
-	    if (family == "qlf_k6n10" ) {
-	    	run("abc -lut 6 ");
-	    }
-	    else {
- 	        run("abc -lut 4 ");
-	    }        
+	    run("abc -lut 6 ");       
 	    run("clean");
             run("opt_lut");
         }

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -187,7 +187,6 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("map_bram", "(skip if -nobram)") && family == "qlf_k6n10" && inferBram) {
             run("memory_bram -rules +/quicklogic/" + family + "_brams.txt");
-      //      run("pp3_braminit");
             run("techmap -map +/quicklogic/" + family + "_brams_map.v");
         }
 
@@ -214,12 +213,10 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("map_ffs")) {
 
-
-//	    run("async2sync");
-            std::string techMapArgs = " -map +/quicklogic/" + family + "_ff_map.v";
+            std::string techMapArgs = " -map +/quicklogic/" + family + "_ffs_map.v";
 
             if (family == "qlf_k4n8" || family == "qlf_k6n10" ) {
-		run(stringf("dfflegalize -cell $_DFF_?_ 0 -cell $_DLATCH_?_ x"));
+		run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFF_P?0_ 0 -cell $_DLATCH_P_ x");
 		}
 	    run("techmap " + techMapArgs);
             run("opt_expr -mux_undef");
@@ -243,7 +240,6 @@ struct SynthQuickLogicPass : public ScriptPass {
         }
 
 	if (check_label("map_cells")){
-	   //TODO: Fix the missing out-going edges error when lut is infered out of lut6 mode
             std::string techMapArgs;
             techMapArgs = "-map +/quicklogic/" + family + "_lut_map.v";
 	    run("techmap " + techMapArgs); 


### PR DESCRIPTION
This pull request adds the following functionality:

- Add yosys script to support heterogenous RAM block with multiple writing mode.
- Enable qlf_k6n10 supported FF techmapping.
- Enable frac_lut6 techmapping in lut6 mode. ABC handles other modes for now.
- Add adder support.

This script has been tested on all QL testcases, as well as the VexriscV benchmark.